### PR TITLE
fix: 添加缺失的 initUse 翻译键

### DIFF
--- a/packages/search-box/src/utils/en_US.ts
+++ b/packages/search-box/src/utils/en_US.ts
@@ -35,7 +35,8 @@ export default {
       equal: 'Equal',
       notEqual: 'Not equal',
       contain: 'Contain',
-      notContain: 'Does not contain'
+      notContain: 'Does not contain',
+      initUse: 'Search'
     }
   }
 }

--- a/packages/search-box/src/utils/zh_CN.ts
+++ b/packages/search-box/src/utils/zh_CN.ts
@@ -35,7 +35,8 @@ export default {
       equal: '等于',
       notEqual: '不等于',
       contain: '包含',
-      notContain: '不包含'
+      notContain: '不包含',
+      initUse: '搜索'
     }
   }
 }


### PR DESCRIPTION
修复了在搜索框中显示 tvp.tvpSearchbox.initUse 键名而非翻译文本的问题，已添加中英文翻译。