### PR TITLE
fix: The prefix icon is on the top.

### DIFF
--- a/packages/search-box/theme-saas/index.less
+++ b/packages/search-box/theme-saas/index.less
@@ -144,8 +144,6 @@
 
   & > &__prefix {
     @apply absolute;
-    @apply top-1/2;
-    @apply ~'-translate-y-2/4';
     @apply left-3;
     @apply inline-block;
     @apply text-base;

--- a/packages/search-box/theme/index.less
+++ b/packages/search-box/theme/index.less
@@ -146,7 +146,6 @@
 
   & > &__prefix {
     position: absolute;
-    top: calc((var(--tvp-SearchBox-min-height) - var(--tvp-SearchBox-left-icon-font-size)) / 2 - 1px);
     left: 12px;
     display: inline;
     font-size: var(--tvp-SearchBox-left-icon-font-size);
@@ -421,7 +420,6 @@
     padding-left: var(--tvp-SearchBox-small-padding-left);
 
     & > .@{search-box-prefix-cls}__prefix {
-      top: calc((var(--tvp-SearchBox-small-min-height) - var(--tvp-SearchBox-left-icon-font-size)) / 2 - 1px);
       left: 10px;
     }
 


### PR DESCRIPTION
fix:前缀图标偏上问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated search box prefix alignment by removing vertical centering, affecting the visual positioning of prefix elements within the search box.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->