### PR TITLE
fix:空数组options时loading一直显示，新增asyncLoading标志区分异步加载场景

### DIFF
--- a/packages/docs/apis/types.md
+++ b/packages/docs/apis/types.md
@@ -25,6 +25,7 @@ interface ISearchBoxItem {
   maxTimeLength?: number; // type=dateRange/datetimeRange时生效，设置用户只能选择某个时间跨度，只接受毫秒数
   slotName?: string; // type=custom时生效，用于指定二级面板的插槽名，对应的编辑态自定义面板插槽名为item.slotName + '-edit'
   groupKey?: string; // 自定义分组名，默认为：'0'
+  asyncLoading?: boolean; // 是否异步加载 options，为 true 时空数组会显示 loading 等待数据；不设置或为 false 时空数组不显示 loading
   [propName: string]: any;
 }
 

--- a/packages/docs/search-box.js
+++ b/packages/docs/search-box.js
@@ -265,6 +265,7 @@ interface ISearchBoxItem {
   maxTimeLength?: number; // type=dateRange/datetimeRange时生效，设置用户只能选择某个时间跨度，只接受毫秒数[3.16.0新增]
   slotName?: string; // type=custom时生效，用于指定二级面板的插槽名[3.16.0新增]，对应的编辑态自定义面板插槽名为item.slotName + '-edit'[注：编辑态只有3.19.0版本及以上才有]
   groupKey?: string; // 自定义分组名，默认为：'0' [3.16.0新增]
+  asyncLoading?: boolean; // 是否异步加载 options，为 true 时空数组会显示 loading 等待数据；不设置或为 false 时空数组不显示 loading [3.29.1版本以上支持]
   [propName: string]: any;
 }
 

--- a/packages/docs/search-box/events-options-api.vue
+++ b/packages/docs/search-box/events-options-api.vue
@@ -28,6 +28,7 @@ export default {
           // 该种单选情况没有可选项。
           label: '名称',
           field: 'testName',
+          asyncLoading: true,
           options: [] // 告知组件有异步options
         },
         {
@@ -36,9 +37,16 @@ export default {
           field: 'testName1'
         },
         {
+          // 空数组 options 且未声明 asyncLoading，不应显示 loading
+          label: '名称2',
+          field: 'testName2',
+          options: []
+        },
+        {
           label: '状态',
           type: 'checkbox',
           field: 'status',
+          asyncLoading: true,
           options: []
         },
         {
@@ -51,6 +59,7 @@ export default {
           field: 'testTag',
           type: 'map',
           searchKeys: ['label', 'id'],
+          asyncLoading: true,
           options: []
         }
       ],
@@ -80,8 +89,8 @@ export default {
               label: 'tms-1'
             }
           ]
-        } else if (field === 'status' && this.items[2].options.length === 0) {
-          this.items[2].options = [
+        } else if (field === 'status' && this.items.find(i => i.field === 'status').options.length === 0) {
+          this.items.find(i => i.field === 'status').options = [
             {
               label: '运行中'
             },
@@ -92,8 +101,8 @@ export default {
               label: '已注销'
             }
           ]
-        } else if (field === 'testTag' && this.items[4].options.length === 0) {
-          this.items[4].options = [
+        } else if (field === 'testTag' && this.items.find(i => i.field === 'testTag').options.length === 0) {
+          this.items.find(i => i.field === 'testTag').options = [
             {
               label: 'aaa',
               id: 'id-1',

--- a/packages/docs/search-box/events.spec.ts
+++ b/packages/docs/search-box/events.spec.ts
@@ -32,3 +32,32 @@ test('事件', async ({ page }) => {
   await container.getByRole('textbox', { name: '添加筛选条件' }).press('Enter')
   await container.locator('.tvp-search-box__input-close').click()
 })
+
+test('asyncLoading - 异步加载时空数组显示 loading，数据到达后消失', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('/examples/events')
+
+  const input = page.getByRole('textbox', { name: '选择属性筛选，或输入关键字搜索' })
+  await input.click()
+  // 选择声明了 asyncLoading: true 的字段（名称，options: []）
+  await page.locator('li').filter({ hasText: '名称' }).first().locator('div').nth(1).click()
+
+  // asyncLoading: true 且 options 为空数组，应显示 loading
+  await expect(page.locator('.tvp-search-box__loading-box')).toBeVisible()
+
+  // 异步数据到达后（setTimeout 1s），loading 消失
+  await expect(page.locator('.tvp-search-box__loading-box')).not.toBeVisible({ timeout: 5000 })
+})
+
+test('无 asyncLoading - 空数组 options 不显示 loading（回归测试）', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('/examples/events')
+
+  const input = page.getByRole('textbox', { name: '选择属性筛选，或输入关键字搜索' })
+  await input.click()
+  // 选择 options 为空数组但未声明 asyncLoading 的字段（名称2）
+  await page.locator('li').filter({ hasText: '名称2' }).locator('div').nth(1).click()
+
+  // 不应出现 loading（未声明 asyncLoading，空数组不触发 loading）
+  await expect(page.locator('.tvp-search-box__loading-box')).not.toBeVisible()
+})

--- a/packages/docs/search-box/events.vue
+++ b/packages/docs/search-box/events.vue
@@ -22,6 +22,7 @@ const items = reactive([
     // 该种单选情况没有可选项。
     label: '名称',
     field: 'testName',
+    asyncLoading: true,
     options: [] // 告知组件有异步options
   },
   {
@@ -30,9 +31,16 @@ const items = reactive([
     field: 'testName1'
   },
   {
+    // 空数组 options 且未声明 asyncLoading，不应显示 loading
+    label: '名称2',
+    field: 'testName2',
+    options: []
+  },
+  {
     label: '状态',
     type: 'checkbox',
     field: 'status',
+    asyncLoading: true,
     options: []
   },
   {
@@ -45,6 +53,7 @@ const items = reactive([
     field: 'testTag',
     type: 'map',
     searchKeys: ['label', 'id'],
+    asyncLoading: true,
     options: []
   }
 ])
@@ -69,8 +78,8 @@ const FirstLevelSelect = (field) => {
           label: 'tms-1'
         }
       ]
-    } else if (field === 'status' && items[2].options.length === 0) {
-      items[2].options = [
+    } else if (field === 'status' && items.find(i => i.field === 'status').options.length === 0) {
+      items.find(i => i.field === 'status').options = [
         {
           label: '运行中'
         },
@@ -81,8 +90,8 @@ const FirstLevelSelect = (field) => {
           label: '已注销'
         }
       ]
-    } else if (field === 'testTag' && items[4].options.length === 0) {
-      items[4].options = [
+    } else if (field === 'testTag' && items.find(i => i.field === 'testTag').options.length === 0) {
+      items.find(i => i.field === 'testTag').options = [
         {
           label: 'aaa',
           id: 'id-1',

--- a/packages/search-box/src/index.type.ts
+++ b/packages/search-box/src/index.type.ts
@@ -97,6 +97,11 @@ export interface ISearchBoxItem {
    * 自定义分组名，默认为：'0'
    */
   groupKey?: string
+  /**
+   * 是否异步加载 options，设置为 true 时 options 为空数组会显示 loading 等待数据填充；
+   * 不设置或为 false 时 options 为空数组不显示 loading
+   */
+  asyncLoading?: boolean
   [propName: string]: any
 }
 

--- a/packages/search-box/src/renderless.ts
+++ b/packages/search-box/src/renderless.ts
@@ -92,10 +92,16 @@ const initState = ({ reactive, computed, api, i18n, watch, props, emit, vm }) =>
     hasFormError: false, // 表单校验错误状态
     hasBackupList: computed(() => {
       if (!state.propItem.label) return false
-      const { type, options } = state.prevItem
+      const { type, options, asyncLoading } = state.prevItem
       // input 类型需要 options 才算有 backupList，避免无 options 时卡在 loading
       if (type === 'input') return !!options?.length
-      return [undefined, null, '', 'radio', 'checkbox', 'map'].includes(type)
+      if ([undefined, null, '', 'radio', 'checkbox', 'map'].includes(type)) {
+        // 异步加载场景：声明 asyncLoading 时空数组也期望有列表，显示 loading 等待数据
+        if (asyncLoading) return true
+        // 非异步场景：options 为空则无 backupList，避免卡在 loading
+        return !!options?.length
+      }
+      return false
     }),
     isIndeterminate: computed(() => state.checkboxGroup.length > 0 && state.checkboxGroup.length !== state.filterList.length),
     checkAll: computed({


### PR DESCRIPTION
options为空数组时hasBackupList恒为true导致isLoading无法关闭，新增asyncLoading字段显式声明异步加载，未声明时空数组不显示loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional asynchronous loading support for SearchBox options.
  * SearchBox can display a loading state while empty option lists are being populated.
  * Loading behavior can be enabled independently for different field types.

* **Bug Fixes**
  * Empty option lists no longer show a loading state unless asynchronous loading is explicitly enabled.

* **Documentation**
  * Updated SearchBox API documentation and examples to describe the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->