### PR TITLE
fix:完善日期/数字范围校验联动，优化日期选择体验

### DIFF
--- a/packages/search-box/src/components/second-level-panel.vue
+++ b/packages/search-box/src/components/second-level-panel.vue
@@ -172,6 +172,7 @@
             :picker-options="pickerOptions(state.startDate, 'endDate')"
             class="tvp-search-box__date-picker"
             @visible-change="handleDateShow"
+            @change="onDateChange(false)"
           ></tiny-date-picker>
         </tiny-form-item>
         <div class="tvp-search-box__dropdown-end">
@@ -184,7 +185,7 @@
             :value-format="state.prevItem.format || state.dateRangeFormat"
             :picker-options="pickerOptions(state.startDate)"
             class="tvp-search-box__date-picker"
-            @change="handleDateShow"
+            @change="onDateChange(false)"
             @blur="handleDateShow"
           ></tiny-date-picker>
         </tiny-form-item>
@@ -193,7 +194,7 @@
         <tiny-button size="mini" @click="onConfirmDate(false)">
           {{ t("tvp.tvpSearchbox.cancel") }}
         </tiny-button>
-        <tiny-button size="mini" @click="onConfirmDate(true)">
+        <tiny-button size="mini" :disabled="isDateRangeInvalid" @click="onConfirmDate(true)">
           {{ t("tvp.tvpSearchbox.confirm") }}
         </tiny-button>
       </div>
@@ -229,7 +230,7 @@
             :value-format="state.prevItem.format || state.datetimeRangeFormat"
             :picker-options="pickerOptions(state.startDateTime, 'endDateTime')"
             class="tvp-search-box__date-picker"
-            @change="handleDateShow"
+            @change="onDateChange(true)"
             @blur="handleDateShow"
           ></tiny-date-picker>
         </tiny-form-item>
@@ -245,7 +246,7 @@
             :value-format="state.prevItem.format || state.datetimeRangeFormat"
             :picker-options="pickerOptions(state.startDateTime)"
             class="tvp-search-box__date-picker"
-            @change="handleDateShow"
+            @change="onDateChange(true)"
             @blur="handleDateShow"
           ></tiny-date-picker>
         </tiny-form-item>
@@ -254,7 +255,7 @@
         <tiny-button size="mini" @click="onConfirmDate(false, true)">
           {{ t("tvp.tvpSearchbox.cancel") }}
         </tiny-button>
-        <tiny-button size="mini" @click="onConfirmDate(true, true)">
+        <tiny-button size="mini" :disabled="isDateRangeInvalid" @click="onConfirmDate(true, true)">
           {{ t("tvp.tvpSearchbox.confirm") }}
         </tiny-button>
       </div>
@@ -310,6 +311,7 @@ import {
 } from '@opentiny/vue'
 import { t } from '../utils/i18n.ts'
 import { useVirtualScroll } from '../composables/use-virtual-scroll.ts'
+import { compareDate } from '../utils/validate.ts'
 
 // 简单的 renderless 函数
 const renderless = (props, hooks, { emit, nextTick, refs }) => {
@@ -347,6 +349,26 @@ const renderless = (props, hooks, { emit, nextTick, refs }) => {
   const handleDateShow = (e) => {
     handleEvents('handleDateShow', e)
   }
+
+  // 日期任一字段变化时，保持下拉面板展开并联动重校验两个字段
+  const onDateChange = (isDateTimeType) => {
+    handleEvents('handleDateShow')
+    handleEvents('validateDateRange', isDateTimeType)
+  }
+
+  // 日期范围是否无效：两个时间都填且结束早于开始时禁用确认按钮
+  const isDateRangeInvalid = computed(() => {
+    const type = props.state.prevItem.type
+    if (type === 'dateRange') {
+      const { startDate, endDate } = props.state
+      return Boolean(startDate && endDate && compareDate(endDate, startDate) < 0)
+    }
+    if (type === 'datetimeRange') {
+      const { startDateTime, endDateTime } = props.state
+      return Boolean(startDateTime && endDateTime && compareDate(endDateTime, startDateTime) < 0)
+    }
+    return false
+  })
 
   const isLoading = computed(() => {
     return props.state.hasBackupList && props.state.backupList?.length === 0
@@ -429,6 +451,8 @@ const renderless = (props, hooks, { emit, nextTick, refs }) => {
     onConfirmDate,
     selectFirstMap,
     handleDateShow,
+    onDateChange,
+    isDateRangeInvalid,
     isLoading,
     showCheckBoxList,
     vsTotalHeight: vs.totalHeight,
@@ -448,6 +472,8 @@ const api = [
   'onConfirmDate',
   'selectFirstMap',
   'handleDateShow',
+  'onDateChange',
+  'isDateRangeInvalid',
   'isLoading',
   'showCheckBoxList',
   'vsTotalHeight',

--- a/packages/search-box/src/composables/use-datepicker.ts
+++ b/packages/search-box/src/composables/use-datepicker.ts
@@ -2,6 +2,13 @@ import { showDropdown } from '../utils/dropdown.ts'
 import { getVerifyDateTag } from '../utils/validate.ts'
 import { emitChangeModelEvent } from '../utils/tag.ts'
 
+// 获取某天的起始时间戳（00:00:00.000），用于 datetime 类型按天禁用日期
+const getStartOfDay = (date) => {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
 export function useDatePicker({ props, state, emit, nextTick, vm }) {
   const instance = vm || state.instance
   const onConfirmDate = async (confirm: boolean, isDateTimeType = false) => {
@@ -26,6 +33,8 @@ export function useDatePicker({ props, state, emit, nextTick, vm }) {
   const pickerOptions = (startDate, endName = '') => ({
     disabledDate(time) {
       const { maxTimeLength = 0, min, max } = state.prevItem
+      // datetime 类型按天禁用日期，避免开始时间非 00:00:00 时结束时间无法选择当天
+      const isDateTime = state.prevItem.type === 'datetimeRange'
 
       const endDate = state[endName]
       const curTime = time.getTime()
@@ -35,11 +44,13 @@ export function useDatePicker({ props, state, emit, nextTick, vm }) {
           if (endName && endDate) {
             const end = new Date(endDate).getTime()
             const start = !min && max ? end - maxTimeLength : Math.max(min.getTime(), end - maxTimeLength)
-            return curTime < start || curTime > end
+            const lower = isDateTime ? getStartOfDay(start) : start
+            return curTime < lower || curTime > end
           } else if (!endName && startDate) {
             const start = new Date(startDate).getTime()
             const end = min && !max ? start + maxTimeLength : Math.min(max.getTime(), start + maxTimeLength)
-            return curTime < start || curTime > end
+            const lower = isDateTime ? getStartOfDay(start) : start
+            return curTime < lower || curTime > end
           } else {
             return (min && curTime < min.getTime()) || (max && curTime > max.getTime())
           }
@@ -47,11 +58,13 @@ export function useDatePicker({ props, state, emit, nextTick, vm }) {
           if (endName && endDate) {
             const end = new Date(endDate).getTime()
             const start = end - maxTimeLength
-            return curTime < start || curTime > end
+            const lower = isDateTime ? getStartOfDay(start) : start
+            return curTime < lower || curTime > end
           } else if (!endName && startDate) {
             const start = new Date(startDate).getTime()
             const end = start + maxTimeLength
-            return curTime < start || curTime > end
+            const lower = isDateTime ? getStartOfDay(start) : start
+            return curTime < lower || curTime > end
           } else {
             return false
           }
@@ -63,7 +76,8 @@ export function useDatePicker({ props, state, emit, nextTick, vm }) {
             return (min && curTime < min.getTime()) || curTime > end
           } else if (!endName && startDate) {
             const start = new Date(startDate).getTime()
-            return curTime < start || (max && curTime > max.getTime())
+            const lower = isDateTime ? getStartOfDay(start) : start
+            return curTime < lower || (max && curTime > max.getTime())
           } else {
             return curTime < min || curTime > max
           }
@@ -73,7 +87,8 @@ export function useDatePicker({ props, state, emit, nextTick, vm }) {
             return curTime > end
           } else if (!endName && startDate) {
             const start = new Date(startDate).getTime()
-            return curTime < start
+            const lower = isDateTime ? getStartOfDay(start) : start
+            return curTime < lower
           } else {
             return false
           }

--- a/packages/search-box/src/composables/use-dropdown.ts
+++ b/packages/search-box/src/composables/use-dropdown.ts
@@ -41,6 +41,13 @@ export function useDropdown({ props, emit, state, t, format, nextTick, vm, cance
       })
     }
 
+    // 清除日期字段的残留校验状态，避免删除标签后重新打开面板时显示过期错误
+    if (type === 'dateRange' || type === 'datetimeRange') {
+      nextTick(() => {
+        instance?.$refs?.formRef?.clearValidate?.(['startDate', 'endDate', 'startDateTime', 'endDateTime'])
+      })
+    }
+
     if (type !== 'checkbox' && state.backupList?.length) {
       state.backupList?.forEach((option) => {
         option.isFilter = false

--- a/packages/search-box/src/composables/use-num-range.ts
+++ b/packages/search-box/src/composables/use-num-range.ts
@@ -1,5 +1,5 @@
 import { showDropdown } from '../utils/dropdown.ts'
-import { getVerifyNumTag } from '../utils/validate.ts'
+import { getVerifyNumTag, compareDate } from '../utils/validate.ts'
 import { emitChangeModelEvent } from '../utils/tag.ts'
 
 export function useNumRange({ props, state, t, emit, nextTick, vm }) {
@@ -46,6 +46,8 @@ export function useNumRange({ props, state, t, emit, nextTick, vm }) {
             cb(new Error(t('tvp.tvpSearchbox.notBeNull')))
           } else if (!value && !state[startKey]) {
             cb(new Error(t('tvp.tvpSearchbox.rangeDateTitle')))
+          } else if (value && state[startKey] && compareDate(value, state[startKey]) < 0) {
+            cb(new Error(t('tvp.tvpSearchbox.rangeDateMaxErr')))
           } else {
             cb()
           }

--- a/packages/search-box/src/pc.vue
+++ b/packages/search-box/src/pc.vue
@@ -318,6 +318,7 @@
                     :value-format="state.prevItem.format || state.dateRangeFormat"
                     :picker-options="pickerOptions(state.startDate, 'endDate')"
                     class="tvp-search-box__date-picker"
+                    @change="checkFormValidation()"
                   ></tiny-date-picker>
                 </tiny-form-item>
                 <div class="tvp-search-box__dropdown-end">
@@ -333,6 +334,7 @@
                     :value-format="state.prevItem.format || state.dateRangeFormat"
                     :picker-options="pickerOptions(state.startDate)"
                     class="tvp-search-box__date-picker"
+                    @change="checkFormValidation()"
                   ></tiny-date-picker>
                 </tiny-form-item>
               </div>
@@ -365,6 +367,7 @@
                     :value-format="state.prevItem.format || state.datetimeRangeFormat"
                     :picker-options="pickerOptions(state.startDateTime, 'endDateTime')"
                     class="tvp-search-box__date-picker"
+                    @change="checkFormValidation()"
                   ></tiny-date-picker>
                 </tiny-form-item>
                 <div class="tvp-search-box__dropdown-end">
@@ -382,6 +385,7 @@
                     :value-format="state.prevItem.format || state.datetimeRangeFormat"
                     :picker-options="pickerOptions(state.startDateTime)"
                     class="tvp-search-box__date-picker"
+                    @change="checkFormValidation()"
                   ></tiny-date-picker>
                 </tiny-form-item>
               </div>

--- a/packages/search-box/src/renderless.ts
+++ b/packages/search-box/src/renderless.ts
@@ -38,6 +38,7 @@ export const api = [
   'selectItemIsDisable',
   'selectPropChange',
   'confirmEditTag',
+  'checkFormValidation',
   'handleConfirm',
   'handleEditConfirm',
   'showDropdown',
@@ -170,6 +171,14 @@ const initAllApi = ({ api, state, t, props, emit, nextTick, vm, computed }) => {
 
   const isShowClose = computed(() => props.modelValue.length || state.propItem.label || state.inputValue)
 
+  // 日期范围任一字段变化时，重新校验开始和结束两个字段，实现联动标红
+  const validateDateRange = (isDateTimeType) => {
+    const verifyProps = isDateTimeType ? ['startDateTime', 'endDateTime'] : ['startDate', 'endDate']
+    nextTick(() => {
+      state.instance?.$refs?.formRef?.validateField(verifyProps, () => {})
+    })
+  }
+
   const eventsMap = () => ({
     selectInputValue,
     selectPropItem,
@@ -179,7 +188,8 @@ const initAllApi = ({ api, state, t, props, emit, nextTick, vm, computed }) => {
     sizeChange,
     onConfirmDate,
     selectFirstMap,
-    handleDateShow
+    handleDateShow,
+    validateDateRange
   })
 
   const setPlaceholder = (placeholderValue: string) => {

--- a/packages/search-box/src/utils/en_US.ts
+++ b/packages/search-box/src/utils/en_US.ts
@@ -23,6 +23,7 @@ export default {
       rangeMaxErr: 'The maximum value must be greater than or equal to the minimum value, or empty',
       rangeNumberTitle: 'Please enter at least one value',
       rangeDateTitle: 'Please enter at least one date',
+      rangeDateMaxErr: 'The end date must be greater than or equal to the start date, or empty',
       timeLengthTitle: 'The optional time span is within {value} days',
       rangeBeginLabel: 'Start date',
       rangeEndLabel: 'End date',

--- a/packages/search-box/src/utils/tag.ts
+++ b/packages/search-box/src/utils/tag.ts
@@ -22,6 +22,10 @@ export const hasTagItem = (state, itemValue, itemLabel = '') => {
 export const resetInput = (state) => {
   state.propItem = {}
   state.inputValue = ''
+  state.startDate = null
+  state.endDate = null
+  state.startDateTime = null
+  state.endDateTime = null
 }
 
 /**

--- a/packages/search-box/src/utils/validate.ts
+++ b/packages/search-box/src/utils/validate.ts
@@ -2,6 +2,21 @@ import { createNewTag, getTagId } from './tag.ts'
 import { isNumber, omitObj } from './index.ts'
 
 /**
+ * 比较两个日期值的大小，返回 -1/0/1
+ * 兼容字符串、时间戳、Date 对象，避免字符串字典序在自定义 format 或带时区时误判
+ * @param a 日期值
+ * @param b 日期值
+ * @returns a<b 返回 -1，a>b 返回 1，相等返回 0
+ */
+export const compareDate = (a, b) => {
+  const ta = new Date(a).getTime()
+  const tb = new Date(b).getTime()
+  if (ta < tb) return -1
+  if (ta > tb) return 1
+  return 0
+}
+
+/**
  * 校验正常标签的值，并返回相应的新标签
  * @param instance searchbox 的 instance
  * @param state searchbox 的 state
@@ -128,9 +143,9 @@ export const getVerifyDateTag = async (instance, state, props, isDateTimeType) =
     const rest = omitObj(prevItem)
     let value = ''
     if (start && end) {
-      if (start > end) {
+      if (compareDate(start, end) > 0) {
         return
-      } else if (start === end) {
+      } else if (compareDate(start, end) === 0) {
         value = start
       } else {
         value = `${start}-${end}`

--- a/packages/search-box/src/utils/zh_CN.ts
+++ b/packages/search-box/src/utils/zh_CN.ts
@@ -23,6 +23,7 @@ export default {
       rangeMaxErr: '最大值必须大于等于最小值，或者为空',
       rangeNumberTitle: '请至少输入一个值',
       rangeDateTitle: '请至少输入一个日期',
+      rangeDateMaxErr: '结束日期必须大于等于开始日期，或者为空',
       timeLengthTitle: '可选时间跨度为{value}天内',
       rangeBeginLabel: '开始日期',
       rangeEndLabel: '结束日期',


### PR DESCRIPTION
fix:完善日期/数字范围校验联动，优化日期选择体验

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Date and date-time range filters now revalidate immediately when picker values change, keeping the panel open.
  - Confirmation is disabled when the end date/time is earlier than the start, with consistent start/end comparison.
  - Improved date-time picker selectable limits by applying constraints on a per-day basis.
  - Clearing or switching date-based filters now clears outdated validation and resets start/end date and date-time values.

- **Localization**
  - Added an English and Chinese validation message for invalid date ranges (end must be ≥ start, or empty).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->