### PR TITLE
fix:修复仅选label时点击清除无反应，统一tag-click事件命名

### DIFF
--- a/packages/search-box/src/composables/use-edit.ts
+++ b/packages/search-box/src/composables/use-edit.ts
@@ -93,7 +93,7 @@ export function useEdit({ props, state, t, nextTick, format, emit, vm }) {
     state.selectValue = tag.label
     state.currentModelValueIndex = index
 
-    emit('tagClick', tag)
+    emit('tag-click', tag)
     setDropdownProps(tag)
   }
 

--- a/packages/search-box/src/composables/use-tag.ts
+++ b/packages/search-box/src/composables/use-tag.ts
@@ -26,14 +26,14 @@ export function useTag({ props, state, emit, nextTick, isTagDisabled }) {
   const clearTag = () => {
     // 仅清除可删除的标签，保留被禁用删除的标签
     const remaining = props.modelValue.filter((item) => isTagDisabled(item))
-    if (remaining.length === props.modelValue.length) return
+    const hasDeletable = remaining.length !== props.modelValue.length
     showDropdown(state, false)
     props.modelValue.forEach((item) => {
       if (!isTagDisabled(item)) changeIsChecked(item)
     })
-    state.propItem = {}
-    state.inputValue = ''
-    emitChangeModelEvent({ emit, state, nextTick, newValue: remaining })
+    // 始终走 emitChangeModelEvent 以共享弹层关闭与输入重置（含日期等状态）；
+    // 仅当有可删除标签被清除时传 newValue 触发 change，避免无变化时多余事件
+    emitChangeModelEvent({ emit, state, nextTick, ...(hasDeletable ? { newValue: remaining } : {}) })
     emit('clear')
   }
 

--- a/packages/search-box/src/pc.vue
+++ b/packages/search-box/src/pc.vue
@@ -525,7 +525,7 @@ export default defineComponent({
       default: ''
     }
   },
-  emits: ['update:modelValue', 'change', 'search', 'exceed', 'first-level-select', 'second-level-enter', 'clear', 'tagClick', 'help', 'validate-error'],
+  emits: ['update:modelValue', 'change', 'search', 'exceed', 'first-level-select', 'second-level-enter', 'clear', 'tag-click', 'help', 'validate-error'],
   components: {
     TinyTag,
     TinyInput,


### PR DESCRIPTION
- clearTag去掉提前return，仅选label(无tag)时也能重置输入并触发clear事件
- 仅当确有可删除tag被清除时才更新modelValue，避免多余的change事件
- emit('tagClick')改为emit('tag-click')，emits声明同步对齐，修复Vue2下@tag-click监听不到

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the tag selection event name for consistent handling when editing tags.
  * Improved tag clearing behavior by ensuring internal state resets correctly.
  * Prevented disabled tags from being removed when clearing tags.
  * Continued emitting the appropriate clear event while avoiding unnecessary model updates when all tags are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->