### PR TITLE
fix:修复二次打开同类型面板虚拟滚动空白及aria-hidden无障碍警告

### DIFF
--- a/packages/search-box/src/composables/use-edit.ts
+++ b/packages/search-box/src/composables/use-edit.ts
@@ -4,7 +4,7 @@ import { showDropdown } from '../utils/dropdown.ts'
 import { deepClone } from '../utils/index.ts'
 
 export function useEdit({ props, state, t, nextTick, format, emit, vm }) {
-  const setDropdownProps = (curTag) => {
+  const setDropdownProps = (curTag, isSwitch = false) => {
     const { operator, value, start, end } = curTag
     const { options, operators, type, mergeTag } = state.prevItem
     if (type === 'custom') {
@@ -21,13 +21,14 @@ export function useEdit({ props, state, t, nextTick, format, emit, vm }) {
       state.endDateTime = format(end, datetimeRangeFormat)
     } else {
       if (mergeTag) {
-        const labels = curTag.options?.flatMap((item) => item.label) || []
+        // 切换属性时清空选中值；配置项的 options 是可选项而非已选项
+        const labels = isSwitch ? [] : curTag.options?.flatMap((item) => item.label) || []
         // 多选编辑态，tiny-select multiple 需要数组
         state.inputEditValue = labels
         state.currentEditSelectTags = labels
       } else {
         // 其他场景使用字符串
-        state.inputEditValue = Array.isArray(value) ? value.join(',') : (value || '')
+        state.inputEditValue = isSwitch ? '' : (Array.isArray(value) ? value.join(',') : (value || ''))
       }
       state.currentEditValue = options
     }
@@ -100,7 +101,7 @@ export function useEdit({ props, state, t, nextTick, format, emit, vm }) {
   const selectPropChange = (item, disabled) => {
     if (disabled) return
     state.prevItem = item
-    setDropdownProps(item)
+    setDropdownProps(item, true)
     // 切换属性类型时检查校验状态
     nextTick(() => {
       checkFormValidation()

--- a/packages/search-box/src/utils/dropdown.ts
+++ b/packages/search-box/src/utils/dropdown.ts
@@ -20,8 +20,11 @@ export const showDropdown = (state, isShow = true) => {
     //   所以只能在关闭时——而非打开时——重置）
     if (state.visible && typeof document !== 'undefined') {
       // 1. 重置 DOM scrollTop，触发原生 scroll 事件更新 vsState
-      document
-        .querySelectorAll('.tvp-search-box__dropdown-menu .tvp-search-box__virtual-list')
+      //    限定在当前实例的 popperElm 范围内，避免多实例互相影响
+      const popperElm = state.instance?.$refs?.dropdownRef?.state?.popperElm
+      const container = popperElm || document
+      container
+        .querySelectorAll('.tvp-search-box__virtual-list')
         .forEach((el) => {
           el.scrollTop = 0
         })

--- a/packages/search-box/src/utils/dropdown.ts
+++ b/packages/search-box/src/utils/dropdown.ts
@@ -13,6 +13,25 @@ export const showDropdown = (state, isShow = true) => {
       }, 0)
     }
   } else {
+    // 关闭前重置虚拟滚动：此时 popper 仍然可见，DOM 元素可访问，
+    // vsInstance 有效。在隐藏前把 scrollTop 归零，下次打开同类型
+    // 面板时就不会因残留滚动位置而空白。
+    // （second-level-panel 的 watch(() => state.visible) 不触发，
+    //   所以只能在关闭时——而非打开时——重置）
+    if (state.visible && typeof document !== 'undefined') {
+      // 1. 重置 DOM scrollTop，触发原生 scroll 事件更新 vsState
+      document
+        .querySelectorAll('.tvp-search-box__dropdown-menu .tvp-search-box__virtual-list')
+        .forEach((el) => {
+          el.scrollTop = 0
+        })
+      // 2. 关闭前将焦点从下拉面板内移出，避免 popover 设置
+      //    aria-hidden 后其后代 li 仍持有焦点而触发无障碍警告
+      const active = document.activeElement as HTMLElement | null
+      if (active?.closest?.('.tvp-search-box__dropdown-menu')) {
+        state.instance?.$refs?.inputRef?.focus?.()
+      }
+    }
     state.visible = false
   }
 }


### PR DESCRIPTION
关闭下拉前重置虚拟滚动DOM scrollTop并移出焦点：scrollTop归零触发原生scroll事件更新vsState，避免残留滚动位置导致重开空白；焦点移出popper后再设aria-hidden，消除后代li持有焦点的无障碍警告

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reset dropdown scroll position when the dropdown is closed.
  * Return focus to the search input when focus remains within the dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->